### PR TITLE
Fix restart due to too large capture array size when using uirbcore

### DIFF
--- a/include/GirsUIRB.config.h
+++ b/include/GirsUIRB.config.h
@@ -199,7 +199,11 @@
 /**
  * Size of capture and receive arrays.
  */
+#if __has_include(<UIRBcore.hpp>)
+#define DEFAULT_CAPTURESIZE 390U // must be even and less than 394
+#else
 #define DEFAULT_CAPTURESIZE 400U // must be even
+#endif
 
 #ifdef RECEIVE
 /**


### PR DESCRIPTION
Default capture size is now automatically reduced from 400 to 390 if UIRBcorelib is included. This fixes #4